### PR TITLE
Added graphql to routes

### DIFF
--- a/start/routes.js
+++ b/start/routes.js
@@ -14,7 +14,21 @@
 */
 
 const Route = use('Route')
+const GraphqlAdonis = use('ApolloServer')
+const schema = require('../app/data/schema');
+
 
 Route.get('/', () => {
   return { greeting: 'Hello world in JSON' }
+})
+
+Route.route('/graphql', ({ request, auth, response }) => {
+  return GraphqlAdonis.graphql({
+    schema,
+    context: { auth }
+  }, request, response)
+}, ['GET', 'POST'])
+
+Route.get('/graphiql', ({ request, response }) => {
+  return GraphqlAdonis.graphiql({ endpointURL: '/graphql' }, request, response)
 })


### PR DESCRIPTION
Firstly, we imported Route which we’ll use to define our routes. Then GraphqlAdonis (the adonis-apollo-server package) and lastly we imported our schema.

Since GraphQL can be served over HTTP GET and POST requests, we defined a /graphql route that accept both requests. Within this route, we call GraphqlAdonis’s graphql() passing to it an object containing our schema and auth object (as the context) as GraphQL options. The graphql() accepts 3 arguments. The first argument is the GraphQL options which is is an object. The remaining arguments are the request and response object respectively. We pass to the schema and auth object as the GraphQL options.

The /graphiql route is solely for testing out the GraphQL server. Though I won’t be using it for testing out the server in this tutorial. I only added it just to show you how to use GraphiQL with your server.